### PR TITLE
Fix handling of 0-tiles

### DIFF
--- a/osm-caching-proxy.php
+++ b/osm-caching-proxy.php
@@ -16,7 +16,7 @@ $z = $_GET['z'] ?? '';
 $x = $_GET['x'] ?? '';
 $y = $_GET['y'] ?? '';
 // If any of the variables are empty or not numeric, terminate the script
-if(empty($z) || empty($x) || empty($y) || !is_numeric($z) || !is_numeric($x) || !is_numeric($y) || $z < 0 || $x < 0 || $y < 0) {
+if(!isset($z) || !isset($x) || !isset($y) || !is_numeric($z) || !is_numeric($x) || !is_numeric($y) || $z < 0 || $x < 0 || $y < 0) {
     die;
 }
 


### PR DESCRIPTION
The use of empty() in verifying the x/y/z values does not allow for tiles containing 0 in the filename. These tiles are used on the lowest zoom-level (showing the world map).
See example #2 in the [PHP documentation](https://www.php.net/manual/en/function.empty.php).

Using isset() should prevent wrongful terminations.